### PR TITLE
DumbTools - Added 'Apple TV v4' and 'Xbox One' to clients list

### DIFF
--- a/Contents/Code/DumbTools.py
+++ b/Contents/Code/DumbTools.py
@@ -3,7 +3,7 @@ import urllib2
 
 
 class DumbKeyboard:
-    clients = ['Plex for iOS', 'Plex Media Player']
+    clients = ['Plex for iOS', 'Plex Media Player', 'Plex for Xbox One', 'Plex for Apple TV']
     KEYS = list('abcdefghijklmnopqrstuvwxyz1234567890-=;[]\\\',./')
     SHIFT_KEYS = list('ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+:{}|\"<>?')
 
@@ -88,7 +88,10 @@ class DumbKeyboard:
 
 
 class DumbPrefs:
-    clients = ['Plex for iOS', 'Plex Media Player', 'OpenPHT', 'Plex for Roku']
+    clients = [
+        'Plex for iOS', 'Plex Media Player', 'OpenPHT',
+        'Plex for Roku', 'Plex for Xbox One', 'Plex for Apple TV'
+        ]
 
     def __init__(self, prefix, oc, title=None, thumb=None):
         self.host = 'http://127.0.0.1:32400'

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -232,8 +232,8 @@ def Media(title, rel_url, page=1, search=False):
 
 	for item in html.xpath('//div[@class="index_container"]//a[contains(@href, "/watch-")]'):
 
-		item_url = item.xpath('./@href')[0]
-		item_title = item.xpath('./h2/text()')[0]
+		item_url = item.get('href')
+		item_title = Regex(r'^Watch +?').sub('', item.get('title'))
 		item_thumb = item.xpath('./img/@src')[0]
 		item_id = item_thumb.split('/')[-1].split('_')[0]
 


### PR DESCRIPTION
_08/17/2016_

Users from Plex forums asked for _Apple TV v4_ and _Xbox One_ Plex clients to be added to _DumbTools_.

- Xbox One Verified ([ref1](https://forums.plex.tv/discussion/comment/1236495/#Comment_1236495), [ref2](https://forums.plex.tv/discussion/comment/1236499/#Comment_1236499))
- Apple TV v4 Verified ([ref](https://forums.plex.tv/discussion/comment/1236786/#Comment_1236786))